### PR TITLE
Improve extensibility

### DIFF
--- a/.changeset/tasty-seas-remember.md
+++ b/.changeset/tasty-seas-remember.md
@@ -1,0 +1,5 @@
+---
+'@oriflame/backstage-plugin-score-card': patch
+---
+
+Improve extensibility by adding `scoreLabel`, to override `scorePercent` and adding a `title` prop to ScoreCardTable component

--- a/packages/app/cypress/integration/scoreboard.ts
+++ b/packages/app/cypress/integration/scoreboard.ts
@@ -27,7 +27,7 @@ describe('score-card', () => {
 
       cy.contains('System scores overview').should('be.visible');
       cy.checkForErrors();
-      cy.get('span:contains("1-2 of 2")').should('be.visible'); // beware, there is also a hidden <P/> element
+      cy.get('span:contains("1-3 of 3")').should('be.visible'); // beware, there is also a hidden <P/> element
       cy.contains('audio-playback').should('be.visible');
       cy.contains('team-c').should('be.visible');
       cy.contains('non-valid-system').should('be.visible');

--- a/plugins/score-card/sample-data/all.json
+++ b/plugins/score-card/sample-data/all.json
@@ -315,5 +315,321 @@
         ]
       }
     ]
+  },
+  {
+    "systemEntityName": "podcast",
+    "systemTier": "A",
+    "SystemDataConfidentiality": "Confidential",
+    "SystemDataSensitivity": ["PII", "Sensitive-PII"],
+    "generatedDateTimeUtc": "2021-07-22 10:00",
+    "scorePercent": 57,
+    "scoreLabel": "C",
+    "scoreSuccess": "partial",
+    "scoringReviewer": "Guest",
+    "scoringReviewDate": "2022-01-04T08:00:00Z",
+    "areaScores": [
+      {
+        "id": 2199,
+        "title": "Code",
+        "scorePercent": 90,
+        "scoreLabel": "A",
+        "scoreSuccess": "success",
+        "scoreEntries": [
+          {
+            "id": 2157,
+            "title": "GitFlow",
+            "scorePercent": 100,
+            "scoreLabel": "A",
+            "scoreSuccess": "success",
+            "scoreHints": "Gitflow: 100%",
+            "details": "..."
+          },
+          {
+            "id": 2159,
+            "title": "Identity Management",
+            "scoreSuccess": "unknown",
+            "details": "..."
+          },
+          {
+            "id": 2163,
+            "title": "Swagger",
+            "scoreSuccess": "unknown",
+            "isOptional": true,
+            "details": "..."
+          },
+          {
+            "id": 2158,
+            "title": "Https",
+            "scoreSuccess": "unknown",
+            "isOptional": true,
+            "details": "..."
+          },
+          {
+            "id": 2153,
+            "title": "Application Insights",
+            "scorePercent": 80,
+            "scoreLabel": "B",
+            "scoreSuccess": ["AppInsights configured", "Dashboard present"],
+            "details": "Lorem ipsum for **AppInsights** sit amet, consectetuer adipiscing elit. Aliquam erat volutpat. In laoreet, magna id viverra tincidunt, sem odio bibendum justo, vel imperdiet sapien wisi sed libero. Nullam at arcu a est sollicitudin euismod. Aliquam id dolor. Fusce nibh. Duis sapien nunc, commodo et, interdum suscipit, sollicitudin et, dolor. Etiam sapien elit, consequat eget, tristique non, venenatis quis, ante. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos hymenaeos. Mauris elementum mauris vitae tortor. Maecenas libero. Duis pulvinar. Pellentesque pretium lectus id turpis. Duis ante orci, molestie vitae vehicula venenatis, tincidunt ac pede. Etiam commodo dui eget wisi. Nunc dapibus tortor vel mi dapibus sollicitudin. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos hymenaeos. Duis risus."
+          }
+        ]
+      },
+      {
+        "id": 3937,
+        "title": "Documentation",
+        "scorePercent": 75,
+        "scoreLabel": "B+",
+        "scoreSuccess": "almost-success",
+        "scoreEntries": [
+          {
+            "id": 3938,
+            "title": "Project introduction",
+            "scorePercent": 100,
+            "scoreSuccess": "success",
+            "scoreHints": "Well structured/documented/linked with the wiki: 100%",
+            "details": "Project home page is linked to **devops wiki**."
+          },
+          {
+            "id": 3940,
+            "title": "Project wiki",
+            "isOptional": false,
+            "scorePercent": 50,
+            "scoreSuccess": "partial",
+            "scoreHints": "Somewhat usefull: 50%",
+            "details": "Project wiki contains basic information however it is not well structured. It contains brief introduction and few pages about the technology used, but it is missing business context, processes description etc."
+          },
+          {
+            "id": 2207,
+            "title": "README",
+            "scoreSuccess": "unknown",
+            "details": "..."
+          },
+          {
+            "id": 2170,
+            "title": "RFP",
+            "scoreSuccess": "unknown",
+            "details": "..."
+          },
+          {
+            "id": 2164,
+            "title": "Architecture Diagrams",
+            "scoreSuccess": "unknown",
+            "details": "..."
+          },
+          {
+            "id": 2205,
+            "title": "SLA",
+            "scorePercent": 0,
+            "scoreSuccess": "unknown",
+            "details": "..."
+          },
+          {
+            "id": 2165,
+            "title": "Business Documentation",
+            "scorePercent": 0,
+            "scoreSuccess": "unknown",
+            "details": "..."
+          },
+          {
+            "id": 2171,
+            "title": "Road Map",
+            "scorePercent": 0,
+            "scoreSuccess": "unknown",
+            "details": "..."
+          }
+        ]
+      },
+      {
+        "id": 2208,
+        "title": "Operations",
+        "scorePercent": 50,
+        "scoreLabel": "D",
+        "scoreSuccess": "partial",
+        "scoreEntries": [
+          {
+            "id": 2210,
+            "title": "Health Checks",
+            "scorePercent": 0,
+            "scoreSuccess": "failure",
+            "details": "Completelly missing healthchecks."
+          },
+          {
+            "id": 2185,
+            "title": "Semantic Versioning",
+            "scorePercent": 0,
+            "scoreSuccess": "unknown",
+            "details": "..."
+          },
+          {
+            "id": 2176,
+            "title": "CI Pipelines",
+            "scorePercent": 0,
+            "scoreSuccess": "unknown",
+            "details": "..."
+          },
+          {
+            "id": 2175,
+            "title": "CD Pipelines",
+            "scorePercent": 0,
+            "scoreSuccess": "unknown",
+            "details": "..."
+          },
+          {
+            "id": 2181,
+            "title": "Insights Dashboard",
+            "scorePercent": 0,
+            "scoreSuccess": "unknown",
+            "details": "..."
+          },
+          {
+            "id": 2173,
+            "title": "Alerts",
+            "scorePercent": 0,
+            "scoreSuccess": "unknown",
+            "details": "..."
+          },
+          {
+            "id": 2184,
+            "title": "Release-Notes",
+            "scorePercent": 0,
+            "scoreSuccess": "unknown",
+            "details": "..."
+          },
+          {
+            "id": 2183,
+            "title": "Release-Annotations-to-App-Insights",
+            "scorePercent": 0,
+            "scoreSuccess": "unknown",
+            "details": "..."
+          },
+          {
+            "id": 2178,
+            "title": "DNS Record",
+            "isOptional": true,
+            "scorePercent": 0,
+            "scoreSuccess": "unknown",
+            "details": "..."
+          },
+          {
+            "id": 2180,
+            "title": "GitOps",
+            "scorePercent": 0,
+            "scoreSuccess": "unknown",
+            "details": "..."
+          },
+          {
+            "id": 2177,
+            "title": "Canary-Checks",
+            "isOptional": true,
+            "scorePercent": 0,
+            "scoreSuccess": "unknown",
+            "details": "...depends on tier/SLA..."
+          },
+          {
+            "id": 2172,
+            "title": "AB Testing",
+            "isOptional": true,
+            "scorePercent": 0,
+            "scoreSuccess": "unknown",
+            "details": "..."
+          },
+          {
+            "id": 3941,
+            "title": "Disaster Recovery Plan",
+            "scorePercent": 0,
+            "scoreSuccess": "unknown",
+            "details": "..."
+          },
+          {
+            "id": 2179,
+            "title": "Data Refresh For Testing Environments",
+            "scorePercent": 0,
+            "scoreSuccess": "unknown",
+            "details": "..."
+          },
+          {
+            "id": 2174,
+            "title": "Basic Ops Handed Over to L2",
+            "scorePercent": 0,
+            "scoreSuccess": "unknown",
+            "details": "..."
+          }
+        ]
+      },
+      {
+        "id": 4333,
+        "title": "Quality",
+        "scorePercent": 25,
+        "scoreLabel": "F",
+        "scoreSuccess": "almost-failure",
+        "scoreEntries": [
+          {
+            "id": 2187,
+            "title": "Code Reviews",
+            "scorePercent": 100,
+            "scoreSuccess": "success",
+            "scoreHints": [
+              "PR requires reviewer",
+              "No override possible",
+              "PRs are well described",
+              "PRs are small",
+              "PRs has comments"
+            ],
+            "details": "Development policy is defined. Code review process is done during the pull request with minimum of 2 reviewers."
+          },
+          {
+            "id": 2191,
+            "title": "Unit Tests",
+            "scorePercent": 0,
+            "scoreSuccess": "unknown",
+            "details": "..."
+          },
+          {
+            "id": 2189,
+            "title": "Integration Tests",
+            "scorePercent": 0,
+            "scoreSuccess": "unknown",
+            "details": "..."
+          },
+          {
+            "id": 2190,
+            "title": "Performance Tests",
+            "scorePercent": 0,
+            "scoreSuccess": "unknown",
+            "details": "..."
+          },
+          {
+            "id": 2186,
+            "title": "Automation Tests",
+            "scorePercent": 0,
+            "scoreSuccess": "unknown",
+            "details": "..."
+          },
+          {
+            "id": 2188,
+            "title": "Design Reviews",
+            "scorePercent": 0,
+            "scoreSuccess": "unknown",
+            "details": "..."
+          }
+        ]
+      },
+      {
+        "id": 4328,
+        "title": "Security",
+        "scorePercent": 10,
+        "scoreLabel": "F",
+        "scoreSuccess": "failure",
+        "scoreEntries": [
+          {
+            "id": 2158,
+            "title": "Https",
+            "scorePercent": 0,
+            "scoreSuccess": "failure",
+            "details": "At least one endpoint accessible without SSL protection"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/plugins/score-card/sample-data/podcast.json
+++ b/plugins/score-card/sample-data/podcast.json
@@ -1,0 +1,316 @@
+{
+  "systemEntityName": "podcast",
+  "systemTier": "A",
+  "SystemDataConfidentiality": "Confidential",
+  "SystemDataSensitivity": ["PII", "Sensitive-PII"],
+  "generatedDateTimeUtc": "2021-07-22 10:00",
+  "scorePercent": 57,
+  "scoreLabel": "C",
+  "scoreSuccess": "partial",
+  "scoringReviewer": "Guest",
+  "scoringReviewDate": "2022-01-04T08:00:00Z",
+  "areaScores": [
+    {
+      "id": 2199,
+      "title": "Code",
+      "scorePercent": 90,
+      "scoreLabel": "A",
+      "scoreSuccess": "success",
+      "scoreEntries": [
+        {
+          "id": 2157,
+          "title": "GitFlow",
+          "scorePercent": 100,
+          "scoreLabel": "A",
+          "scoreSuccess": "success",
+          "scoreHints": "Gitflow: 100%",
+          "details": "..."
+        },
+        {
+          "id": 2159,
+          "title": "Identity Management",
+          "scoreSuccess": "unknown",
+          "details": "..."
+        },
+        {
+          "id": 2163,
+          "title": "Swagger",
+          "scoreSuccess": "unknown",
+          "isOptional": true,
+          "details": "..."
+        },
+        {
+          "id": 2158,
+          "title": "Https",
+          "scoreSuccess": "unknown",
+          "isOptional": true,
+          "details": "..."
+        },
+        {
+          "id": 2153,
+          "title": "Application Insights",
+          "scorePercent": 80,
+          "scoreLabel": "B",
+          "scoreSuccess": ["AppInsights configured", "Dashboard present"],
+          "details": "Lorem ipsum for **AppInsights** sit amet, consectetuer adipiscing elit. Aliquam erat volutpat. In laoreet, magna id viverra tincidunt, sem odio bibendum justo, vel imperdiet sapien wisi sed libero. Nullam at arcu a est sollicitudin euismod. Aliquam id dolor. Fusce nibh. Duis sapien nunc, commodo et, interdum suscipit, sollicitudin et, dolor. Etiam sapien elit, consequat eget, tristique non, venenatis quis, ante. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos hymenaeos. Mauris elementum mauris vitae tortor. Maecenas libero. Duis pulvinar. Pellentesque pretium lectus id turpis. Duis ante orci, molestie vitae vehicula venenatis, tincidunt ac pede. Etiam commodo dui eget wisi. Nunc dapibus tortor vel mi dapibus sollicitudin. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos hymenaeos. Duis risus."
+        }
+      ]
+    },
+    {
+      "id": 3937,
+      "title": "Documentation",
+      "scorePercent": 75,
+      "scoreLabel": "B+",
+      "scoreSuccess": "almost-success",
+      "scoreEntries": [
+        {
+          "id": 3938,
+          "title": "Project introduction",
+          "scorePercent": 100,
+          "scoreSuccess": "success",
+          "scoreHints": "Well structured/documented/linked with the wiki: 100%",
+          "details": "Project home page is linked to **devops wiki**."
+        },
+        {
+          "id": 3940,
+          "title": "Project wiki",
+          "isOptional": false,
+          "scorePercent": 50,
+          "scoreSuccess": "partial",
+          "scoreHints": "Somewhat usefull: 50%",
+          "details": "Project wiki contains basic information however it is not well structured. It contains brief introduction and few pages about the technology used, but it is missing business context, processes description etc."
+        },
+        {
+          "id": 2207,
+          "title": "README",
+          "scoreSuccess": "unknown",
+          "details": "..."
+        },
+        {
+          "id": 2170,
+          "title": "RFP",
+          "scoreSuccess": "unknown",
+          "details": "..."
+        },
+        {
+          "id": 2164,
+          "title": "Architecture Diagrams",
+          "scoreSuccess": "unknown",
+          "details": "..."
+        },
+        {
+          "id": 2205,
+          "title": "SLA",
+          "scorePercent": 0,
+          "scoreSuccess": "unknown",
+          "details": "..."
+        },
+        {
+          "id": 2165,
+          "title": "Business Documentation",
+          "scorePercent": 0,
+          "scoreSuccess": "unknown",
+          "details": "..."
+        },
+        {
+          "id": 2171,
+          "title": "Road Map",
+          "scorePercent": 0,
+          "scoreSuccess": "unknown",
+          "details": "..."
+        }
+      ]
+    },
+    {
+      "id": 2208,
+      "title": "Operations",
+      "scorePercent": 50,
+      "scoreLabel": "D",
+      "scoreSuccess": "partial",
+      "scoreEntries": [
+        {
+          "id": 2210,
+          "title": "Health Checks",
+          "scorePercent": 0,
+          "scoreSuccess": "failure",
+          "details": "Completelly missing healthchecks."
+        },
+        {
+          "id": 2185,
+          "title": "Semantic Versioning",
+          "scorePercent": 0,
+          "scoreSuccess": "unknown",
+          "details": "..."
+        },
+        {
+          "id": 2176,
+          "title": "CI Pipelines",
+          "scorePercent": 0,
+          "scoreSuccess": "unknown",
+          "details": "..."
+        },
+        {
+          "id": 2175,
+          "title": "CD Pipelines",
+          "scorePercent": 0,
+          "scoreSuccess": "unknown",
+          "details": "..."
+        },
+        {
+          "id": 2181,
+          "title": "Insights Dashboard",
+          "scorePercent": 0,
+          "scoreSuccess": "unknown",
+          "details": "..."
+        },
+        {
+          "id": 2173,
+          "title": "Alerts",
+          "scorePercent": 0,
+          "scoreSuccess": "unknown",
+          "details": "..."
+        },
+        {
+          "id": 2184,
+          "title": "Release-Notes",
+          "scorePercent": 0,
+          "scoreSuccess": "unknown",
+          "details": "..."
+        },
+        {
+          "id": 2183,
+          "title": "Release-Annotations-to-App-Insights",
+          "scorePercent": 0,
+          "scoreSuccess": "unknown",
+          "details": "..."
+        },
+        {
+          "id": 2178,
+          "title": "DNS Record",
+          "isOptional": true,
+          "scorePercent": 0,
+          "scoreSuccess": "unknown",
+          "details": "..."
+        },
+        {
+          "id": 2180,
+          "title": "GitOps",
+          "scorePercent": 0,
+          "scoreSuccess": "unknown",
+          "details": "..."
+        },
+        {
+          "id": 2177,
+          "title": "Canary-Checks",
+          "isOptional": true,
+          "scorePercent": 0,
+          "scoreSuccess": "unknown",
+          "details": "...depends on tier/SLA..."
+        },
+        {
+          "id": 2172,
+          "title": "AB Testing",
+          "isOptional": true,
+          "scorePercent": 0,
+          "scoreSuccess": "unknown",
+          "details": "..."
+        },
+        {
+          "id": 3941,
+          "title": "Disaster Recovery Plan",
+          "scorePercent": 0,
+          "scoreSuccess": "unknown",
+          "details": "..."
+        },
+        {
+          "id": 2179,
+          "title": "Data Refresh For Testing Environments",
+          "scorePercent": 0,
+          "scoreSuccess": "unknown",
+          "details": "..."
+        },
+        {
+          "id": 2174,
+          "title": "Basic Ops Handed Over to L2",
+          "scorePercent": 0,
+          "scoreSuccess": "unknown",
+          "details": "..."
+        }
+      ]
+    },
+    {
+      "id": 4333,
+      "title": "Quality",
+      "scorePercent": 25,
+      "scoreLabel": "F",
+      "scoreSuccess": "almost-failure",
+      "scoreEntries": [
+        {
+          "id": 2187,
+          "title": "Code Reviews",
+          "scorePercent": 100,
+          "scoreSuccess": "success",
+          "scoreHints": [
+            "PR requires reviewer",
+            "No override possible",
+            "PRs are well described",
+            "PRs are small",
+            "PRs has comments"
+          ],
+          "details": "Development policy is defined. Code review process is done during the pull request with minimum of 2 reviewers."
+        },
+        {
+          "id": 2191,
+          "title": "Unit Tests",
+          "scorePercent": 0,
+          "scoreSuccess": "unknown",
+          "details": "..."
+        },
+        {
+          "id": 2189,
+          "title": "Integration Tests",
+          "scorePercent": 0,
+          "scoreSuccess": "unknown",
+          "details": "..."
+        },
+        {
+          "id": 2190,
+          "title": "Performance Tests",
+          "scorePercent": 0,
+          "scoreSuccess": "unknown",
+          "details": "..."
+        },
+        {
+          "id": 2186,
+          "title": "Automation Tests",
+          "scorePercent": 0,
+          "scoreSuccess": "unknown",
+          "details": "..."
+        },
+        {
+          "id": 2188,
+          "title": "Design Reviews",
+          "scorePercent": 0,
+          "scoreSuccess": "unknown",
+          "details": "..."
+        }
+      ]
+    },
+    {
+      "id": 4328,
+      "title": "Security",
+      "scorePercent": 10,
+      "scoreLabel": "F",
+      "scoreSuccess": "failure",
+      "scoreEntries": [
+        {
+          "id": 2158,
+          "title": "Https",
+          "scorePercent": 0,
+          "scoreSuccess": "failure",
+          "details": "At least one endpoint accessible without SSL protection"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/score-card/src/api/ScoringDataJsonClient.ts
+++ b/plugins/score-card/src/api/ScoringDataJsonClient.ts
@@ -19,6 +19,7 @@ import { SystemScore, SystemScoreExtended } from './types';
 import { CatalogApi } from '@backstage/plugin-catalog-react';
 import {
   Entity,
+  CompoundEntityRef,
   getCompoundEntityRef,
   parseEntityRef,
   RELATION_OWNED_BY,
@@ -122,9 +123,15 @@ export class ScoringDataJsonClient implements ScoringDataApi {
     const owner = catalogEntity?.relations?.find(
       r => r.type === RELATION_OWNED_BY,
     )?.targetRef;
-    const reviewer = score.scoringReviewer
-      ? { name: score.scoringReviewer, kind: 'User', namespace: 'default' }
-      : undefined;
+
+    let reviewer = undefined;
+    if (score.scoringReviewer && !(score.scoringReviewer as CompoundEntityRef)?.name) {
+      reviewer = { name: score.scoringReviewer as string, kind: 'User', namespace: 'default' };
+    } else if ((score.scoringReviewer as CompoundEntityRef)?.name) {
+      const scoringReviewer = score.scoringReviewer as CompoundEntityRef
+      reviewer = { name: scoringReviewer.name, kind: scoringReviewer?.kind ?? "User", namespace: scoringReviewer?.namespace ?? 'default' };
+    }
+
     const reviewDate = score.scoringReviewDate
       ? new Date(score.scoringReviewDate)
       : undefined;

--- a/plugins/score-card/src/api/types.ts
+++ b/plugins/score-card/src/api/types.ts
@@ -21,7 +21,7 @@ export interface SystemScore {
   scorePercent: number;
   scoreSuffix?: string;
   scoreSuccess: ScoreSuccessEnum;
-  scoringReviewer: string | undefined | null;
+  scoringReviewer: string | CompoundEntityRef | undefined | null;
   scoringReviewDate: Date | string | undefined | null;
   areaScores: SystemScoreArea[];
 }

--- a/plugins/score-card/src/api/types.ts
+++ b/plugins/score-card/src/api/types.ts
@@ -19,6 +19,7 @@ export interface SystemScore {
   systemEntityName: string;
   generatedDateTimeUtc: Date | string;
   scorePercent: number;
+  scoreSuffix?: string;
   scoreSuccess: ScoreSuccessEnum;
   scoringReviewer: string | undefined | null;
   scoringReviewDate: Date | string | undefined | null;
@@ -29,6 +30,7 @@ export interface SystemScoreArea {
   id: number;
   title: string;
   scorePercent: number;
+  scoreSuffix?: string;
   scoreSuccess: ScoreSuccessEnum;
   scoreEntries: SystemScoreEntry[];
 }
@@ -38,6 +40,7 @@ export interface SystemScoreEntry {
   title: string;
   isOptional: boolean;
   scorePercent: number;
+  scoreSuffix?: string;
   scoreSuccess: ScoreSuccessEnum;
   scoreHints: string | string[];
   details: string;

--- a/plugins/score-card/src/api/types.ts
+++ b/plugins/score-card/src/api/types.ts
@@ -19,7 +19,6 @@ export interface SystemScore {
   systemEntityName: string;
   generatedDateTimeUtc: Date | string;
   scorePercent: number;
-  scoreSuffix?: string;
   scoreSuccess: ScoreSuccessEnum;
   scoringReviewer: string | CompoundEntityRef | undefined | null;
   scoringReviewDate: Date | string | undefined | null;
@@ -30,7 +29,6 @@ export interface SystemScoreArea {
   id: number;
   title: string;
   scorePercent: number;
-  scoreSuffix?: string;
   scoreSuccess: ScoreSuccessEnum;
   scoreEntries: SystemScoreEntry[];
 }
@@ -40,7 +38,6 @@ export interface SystemScoreEntry {
   title: string;
   isOptional: boolean;
   scorePercent: number;
-  scoreSuffix?: string;
   scoreSuccess: ScoreSuccessEnum;
   scoreHints: string | string[];
   details: string;

--- a/plugins/score-card/src/api/types.ts
+++ b/plugins/score-card/src/api/types.ts
@@ -19,6 +19,7 @@ export interface SystemScore {
   systemEntityName: string;
   generatedDateTimeUtc: Date | string;
   scorePercent: number;
+  scoreLabel?: string;
   scoreSuccess: ScoreSuccessEnum;
   scoringReviewer: string | CompoundEntityRef | undefined | null;
   scoringReviewDate: Date | string | undefined | null;
@@ -29,6 +30,7 @@ export interface SystemScoreArea {
   id: number;
   title: string;
   scorePercent: number;
+  scoreLabel?: string;
   scoreSuccess: ScoreSuccessEnum;
   scoreEntries: SystemScoreEntry[];
 }
@@ -38,6 +40,7 @@ export interface SystemScoreEntry {
   title: string;
   isOptional: boolean;
   scorePercent: number;
+  scoreLabel?: string;
   scoreSuccess: ScoreSuccessEnum;
   scoreHints: string | string[];
   details: string;

--- a/plugins/score-card/src/components/ScoreCard/ScoreCard.test.tsx
+++ b/plugins/score-card/src/components/ScoreCard/ScoreCard.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React from 'react';
-import { act, render, within} from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { ScoreCard } from './ScoreCard';
 import { TestApiProvider } from '@backstage/test-utils';
 import { ScoringDataApi, scoringDataApiRef } from '../../api';

--- a/plugins/score-card/src/components/ScoreCard/ScoreCard.test.tsx
+++ b/plugins/score-card/src/components/ScoreCard/ScoreCard.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React from 'react';
-import { act, render } from '@testing-library/react';
+import { act, render, within} from '@testing-library/react';
 import { ScoreCard } from './ScoreCard';
 import { TestApiProvider } from '@backstage/test-utils';
 import { ScoringDataApi, scoringDataApiRef } from '../../api';
@@ -92,7 +92,7 @@ describe('ScoreCard-TestWithData', () => {
     ): Promise<SystemScoreExtended | undefined> {
       return new Promise<SystemScoreExtended | undefined>(
         (resolve, _reject) => {
-          const sampleData = require('../../../sample-data/audio-playback.json');
+          const sampleData = require('../../../sample-data/podcast.json');
           resolve(sampleData);
         },
       );
@@ -138,5 +138,28 @@ describe('ScoreCard-TestWithData', () => {
 
     await findByTestId('score-card');
     jest.useRealTimers();
+  });
+
+  it('should render the score label when provided', async () => {
+    const { findByText } = render(
+      <ThemeProvider theme={lightTheme}>
+        <TestApiProvider
+          apis={[
+            [errorApiRef, sharedErrorApi],
+            [scoringDataApiRef, mockClient],
+            [configApiRef, sharedConfigApiMock],
+          ]}
+        >
+          <EntityProvider entity={entity}>
+            <ScoreCard />
+          </EntityProvider>
+        </TestApiProvider>
+      </ThemeProvider>,
+    );
+
+    await findByText('Total score: C');
+
+    const codeScore = await findByText('Code');
+    expect(codeScore.querySelector('div')).toHaveTextContent('A');
   });
 });

--- a/plugins/score-card/src/components/ScoreCard/ScoreCard.tsx
+++ b/plugins/score-card/src/components/ScoreCard/ScoreCard.tsx
@@ -107,7 +107,8 @@ export const ScoreCard = ({
     backgroundColor: scoreToColorConverter(data?.scoreSuccess),
   };
   if (data?.scorePercent || data?.scorePercent === 0) {
-    gateLabel = `Total score: ${data?.scorePercent} %`;
+    const label = data?.scoreLabel ?? `${data.scorePercent} %`;
+    gateLabel = `Total score: ${label}`;
   }
   const qualityBadge = !loading && <Chip label={gateLabel} style={gateStyle} />;
 

--- a/plugins/score-card/src/components/ScoreCard/ScoreCard.tsx
+++ b/plugins/score-card/src/components/ScoreCard/ScoreCard.tsx
@@ -107,7 +107,7 @@ export const ScoreCard = ({
     backgroundColor: scoreToColorConverter(data?.scoreSuccess),
   };
   if (data?.scorePercent || data?.scorePercent === 0) {
-    gateLabel = `Total score: ${data?.scorePercent}${data?.scoreSuffix ?? " %"}`;
+    gateLabel = `Total score: ${data?.scorePercent} %`;
   }
   const qualityBadge = !loading && <Chip label={gateLabel} style={gateStyle} />;
 

--- a/plugins/score-card/src/components/ScoreCard/ScoreCard.tsx
+++ b/plugins/score-card/src/components/ScoreCard/ScoreCard.tsx
@@ -107,7 +107,7 @@ export const ScoreCard = ({
     backgroundColor: scoreToColorConverter(data?.scoreSuccess),
   };
   if (data?.scorePercent || data?.scorePercent === 0) {
-    gateLabel = `Total score: ${data?.scorePercent} %`;
+    gateLabel = `Total score: ${data?.scorePercent}${data?.scoreSuffix ?? " %"}`;
   }
   const qualityBadge = !loading && <Chip label={gateLabel} style={gateStyle} />;
 

--- a/plugins/score-card/src/components/ScoreCard/columns/areaColumn.tsx
+++ b/plugins/score-card/src/components/ScoreCard/columns/areaColumn.tsx
@@ -42,7 +42,7 @@ export function areaColumn(
           float: 'right',
           minWidth: '4rem',
         };
-        const areaGateLabel = `${area?.scorePercent}${area?.scoreSuffix ?? " %"}`;
+        const areaGateLabel = `${area?.scorePercent} %`;
         return (
           <span>
             <>

--- a/plugins/score-card/src/components/ScoreCard/columns/areaColumn.tsx
+++ b/plugins/score-card/src/components/ScoreCard/columns/areaColumn.tsx
@@ -42,7 +42,7 @@ export function areaColumn(
           float: 'right',
           minWidth: '4rem',
         };
-        const areaGateLabel = `${area?.scorePercent} %`;
+        const areaGateLabel = `${area?.scorePercent}${area?.scoreSuffix ?? " %"}`;
         return (
           <span>
             <>

--- a/plugins/score-card/src/components/ScoreCard/columns/areaColumn.tsx
+++ b/plugins/score-card/src/components/ScoreCard/columns/areaColumn.tsx
@@ -42,7 +42,7 @@ export function areaColumn(
           float: 'right',
           minWidth: '4rem',
         };
-        const areaGateLabel = area?.scoreLabel ?? `${area?.scorePercent} %*`;
+        const areaGateLabel = area?.scoreLabel ?? `${area?.scorePercent} %`;
         return (
           <span>
             <>

--- a/plugins/score-card/src/components/ScoreCard/columns/areaColumn.tsx
+++ b/plugins/score-card/src/components/ScoreCard/columns/areaColumn.tsx
@@ -42,7 +42,7 @@ export function areaColumn(
           float: 'right',
           minWidth: '4rem',
         };
-        const areaGateLabel = `${area?.scorePercent} %`;
+        const areaGateLabel = area?.scoreLabel ?? `${area?.scorePercent} %*`;
         return (
           <span>
             <>

--- a/plugins/score-card/src/components/ScoreCard/columns/scorePercentColumn.tsx
+++ b/plugins/score-card/src/components/ScoreCard/columns/scorePercentColumn.tsx
@@ -33,7 +33,7 @@ export const scorePercentColumn: TableColumn<SystemScoreTableEntry> = {
       minWidth: '4rem',
     };
     return typeof systemScoreEntry.scorePercent !== 'undefined' ? (
-      <Chip label={`${systemScoreEntry.scorePercent}${systemScoreEntry?.scoreSuffix ?? ' %'}`} style={chipStyle} />
+      <Chip label={`${systemScoreEntry.scorePercent} %`} style={chipStyle} />
     ) : null;
   },
 };

--- a/plugins/score-card/src/components/ScoreCard/columns/scorePercentColumn.tsx
+++ b/plugins/score-card/src/components/ScoreCard/columns/scorePercentColumn.tsx
@@ -33,7 +33,7 @@ export const scorePercentColumn: TableColumn<SystemScoreTableEntry> = {
       minWidth: '4rem',
     };
     return typeof systemScoreEntry.scorePercent !== 'undefined' ? (
-      <Chip label={`${systemScoreEntry.scorePercent} %`} style={chipStyle} />
+      <Chip label={`${systemScoreEntry.scorePercent}${systemScoreEntry?.scoreSuffix ?? ' %'}`} style={chipStyle} />
     ) : null;
   },
 };

--- a/plugins/score-card/src/components/ScoreCard/columns/scorePercentColumn.tsx
+++ b/plugins/score-card/src/components/ScoreCard/columns/scorePercentColumn.tsx
@@ -32,8 +32,9 @@ export const scorePercentColumn: TableColumn<SystemScoreTableEntry> = {
       backgroundColor: scoreToColorConverter(systemScoreEntry?.scoreSuccess),
       minWidth: '4rem',
     };
+    const label = systemScoreEntry?.scoreLabel ?? `${systemScoreEntry.scorePercent} %`;
     return typeof systemScoreEntry.scorePercent !== 'undefined' ? (
-      <Chip label={`${systemScoreEntry.scorePercent} %`} style={chipStyle} />
+      <Chip label={label} style={chipStyle} />
     ) : null;
   },
 };

--- a/plugins/score-card/src/components/ScoreCardTable/ScoreCardTable.test.tsx
+++ b/plugins/score-card/src/components/ScoreCardTable/ScoreCardTable.test.tsx
@@ -68,3 +68,67 @@ describe('ScoreBoardPage-EmptyData', () => {
     jest.useRealTimers();
   });
 });
+
+
+describe('ScoreCard-TestWithData', () => {
+    class MockClient implements ScoringDataApi {
+    getScore(
+      _entity?: Entity | undefined,
+    ): Promise<SystemScoreExtended | undefined> {
+      throw new Error('Method not implemented.');
+    }
+    getAllScores(): Promise<SystemScoreExtended[] | undefined> {
+      return new Promise<SystemScoreExtended[] | undefined>(
+        (resolve, _reject) => {
+          const sampleData = require('../../../sample-data/all.json');
+          resolve(sampleData);
+        },
+      );
+    }
+  }
+
+  const mockClient = new MockClient();
+
+  // TODO: find how to stop render the progress bar and display the ScoreCardTable
+  // it('should render title', async () => {
+  //   jest.useFakeTimers();
+
+  //   const errorApi = { post: () => {} };
+  //   const { container } = render(
+  //     <ThemeProvider theme={lightTheme}>
+  //       <TestApiProvider
+  //         apis={[
+  //           [errorApiRef, errorApi],
+  //           [scoringDataApiRef, mockClient],
+  //         ]}
+  //       >
+  //         <ScoreCardTable title="Custom title"/>
+  //       </TestApiProvider>
+  //     </ThemeProvider>,
+  //   );
+
+  //   expect(container).toHaveTextContent('Custom title');
+  // });
+
+  it('should render scoreLabel', async () => {
+    const errorApi = { post: () => {} };
+    const { getByText, findByTestId } = render(
+      <ThemeProvider theme={lightTheme}>
+        <TestApiProvider
+          apis={[
+            [errorApiRef, errorApi],
+            [scoringDataApiRef, mockClient],
+          ]}
+        >
+          <ScoreCardTable />
+        </TestApiProvider>
+      </ThemeProvider>,
+    );
+
+    await findByTestId('score-board-table');
+
+    const podcastColumn = await getByText('podcast');
+    const podcastRow = podcastColumn.closest("tr");
+    expect(podcastRow).toHaveTextContent('AB+DFFC');
+  });
+});

--- a/plugins/score-card/src/components/ScoreCardTable/ScoreCardTable.tsx
+++ b/plugins/score-card/src/components/ScoreCardTable/ScoreCardTable.tsx
@@ -130,9 +130,10 @@ export const ScoreTable = ({ title, scores }: ScoreTableProps) => {
             ),
             minWidth: '4rem',
           };
+          const label = currentScoreEntry?.scoreLabel ?? `${currentScoreEntry?.scorePercent} %`;
           return typeof currentScoreEntry?.scorePercent !== 'undefined' ? (
             <Chip
-              label={`${currentScoreEntry?.scorePercent} %`}
+              label={label}
               style={chipStyle}
             />
           ) : null;
@@ -152,8 +153,9 @@ export const ScoreTable = ({ title, scores }: ScoreTableProps) => {
         float: 'right',
         minWidth: '4rem',
       };
+      const label = systemScoreEntry?.scoreLabel ?? `${systemScoreEntry?.scorePercent} %`;
       return typeof systemScoreEntry.scorePercent !== 'undefined' ? (
-        <Chip label={`${systemScoreEntry.scorePercent} %`} style={chipStyle} />
+        <Chip label={label} style={chipStyle} />
       ) : null;
     },
   });

--- a/plugins/score-card/src/components/ScoreCardTable/ScoreCardTable.tsx
+++ b/plugins/score-card/src/components/ScoreCardTable/ScoreCardTable.tsx
@@ -132,7 +132,7 @@ export const ScoreTable = ({ title, scores }: ScoreTableProps) => {
           };
           return typeof currentScoreEntry?.scorePercent !== 'undefined' ? (
             <Chip
-              label={`${currentScoreEntry?.scorePercent}${currentScoreEntry?.scoreSuffix ?? ' %'}`}
+              label={`${currentScoreEntry?.scorePercent} %`}
               style={chipStyle}
             />
           ) : null;
@@ -153,7 +153,7 @@ export const ScoreTable = ({ title, scores }: ScoreTableProps) => {
         minWidth: '4rem',
       };
       return typeof systemScoreEntry.scorePercent !== 'undefined' ? (
-        <Chip label={`${systemScoreEntry.scorePercent}${systemScoreEntry?.scoreSuffix ?? ' %'}`} style={chipStyle} />
+        <Chip label={`${systemScoreEntry.scorePercent} %`} style={chipStyle} />
       ) : null;
     },
   });

--- a/plugins/score-card/src/components/ScoreCardTable/ScoreCardTable.tsx
+++ b/plugins/score-card/src/components/ScoreCardTable/ScoreCardTable.tsx
@@ -43,10 +43,11 @@ const useScoringAllDataLoader = () => {
 };
 
 type ScoreTableProps = {
+  title?: string;
   scores: SystemScoreExtended[];
 };
 
-export const ScoreTable = ({ scores }: ScoreTableProps) => {
+export const ScoreTable = ({ title, scores }: ScoreTableProps) => {
   const columns: TableColumn<SystemScoreExtended>[] = [
     {
       title: 'Name',
@@ -178,7 +179,7 @@ export const ScoreTable = ({ scores }: ScoreTableProps) => {
   return (
     <div data-testid="score-board-table">
       <Table<SystemScoreExtended>
-        title="System scores overview"
+        title={title ?? "System scores overview"}
         options={{
           search: true,
           paging: true,
@@ -193,7 +194,10 @@ export const ScoreTable = ({ scores }: ScoreTableProps) => {
   );
 };
 
-export const ScoreCardTable = () => {
+type ScoreCardTableProps = {
+  title?: string;
+};
+export const ScoreCardTable = ({title}: ScoreCardTableProps) => {
   const { loading, error, value: data } = useScoringAllDataLoader();
 
   if (loading) {
@@ -202,5 +206,5 @@ export const ScoreCardTable = () => {
     return getWarningPanel(error);
   }
 
-  return <ScoreTable scores={data || []} />;
+  return <ScoreTable title={title} scores={data || []} />;
 };

--- a/plugins/score-card/src/components/ScoreCardTable/ScoreCardTable.tsx
+++ b/plugins/score-card/src/components/ScoreCardTable/ScoreCardTable.tsx
@@ -131,7 +131,7 @@ export const ScoreTable = ({ scores }: ScoreTableProps) => {
           };
           return typeof currentScoreEntry?.scorePercent !== 'undefined' ? (
             <Chip
-              label={`${currentScoreEntry?.scorePercent} %`}
+              label={`${currentScoreEntry?.scorePercent}${currentScoreEntry?.scoreSuffix ?? ' %'}`}
               style={chipStyle}
             />
           ) : null;
@@ -152,7 +152,7 @@ export const ScoreTable = ({ scores }: ScoreTableProps) => {
         minWidth: '4rem',
       };
       return typeof systemScoreEntry.scorePercent !== 'undefined' ? (
-        <Chip label={`${systemScoreEntry.scorePercent} %`} style={chipStyle} />
+        <Chip label={`${systemScoreEntry.scorePercent}${systemScoreEntry?.scoreSuffix ?? ' %'}`} style={chipStyle} />
       ) : null;
     },
   });


### PR DESCRIPTION
Hi,
I made a few changes to improve the extensibility of this plugin:


- Adding `title` prop to `ScoreCardTable`:
![image](https://user-images.githubusercontent.com/5289520/205327137-98d98194-386e-4387-a9ea-b7b29fab9ce6.png)

- Adding ability to remove/change the `%` suffix in scores with `scoreSuffix`:
![image](https://user-images.githubusercontent.com/5289520/205327837-692b4102-02b2-4b8f-9e61-dd6a68c46db4.png)
![image](https://user-images.githubusercontent.com/5289520/205336605-38076867-7f30-4428-8ca1-e9e1660faaa8.png)


- Adding ability to specify `reviewer` ref object in json data, in addition to the string:
```json
    "owner": {
      "name": "team-seal",
      "kind": "Group"
    },
```

If that's something you'd consider, I'll update the tests and documentation.

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
