### PR TITLE
Add ability to override Entity scorecard path

### DIFF
--- a/packages/entities/test-entity.yaml
+++ b/packages/entities/test-entity.yaml
@@ -78,3 +78,17 @@ spec:
   lifecycle: experimental
   providesApis:
     - sample-service-3
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: sample-system-1
+  description: |
+    A sample system
+  annotations:
+    score-card/url: /url/to/score/card.json
+
+spec:
+  owner: team-a
+  lifecycle: experimental

--- a/plugins/score-card/src/api/ScoringDataJsonClient.ts
+++ b/plugins/score-card/src/api/ScoringDataJsonClient.ts
@@ -53,9 +53,8 @@ export class ScoringDataJsonClient implements ScoringDataApi {
       return undefined;
     }
     const systemName = entity.metadata.name;
-    const jsonDataUrl = this.getJsonDataUrl();
-    const urlWithData = `${jsonDataUrl}${systemName}.json`;
-    const result: SystemScore = await fetch(urlWithData).then(res => {
+    const scoreCardUrl = entity?.metadata?.annotations['score-card/url'] ?? `${this.getJsonDataUrl()}${systemName}.json`;
+    const result: SystemScore = await fetch(scoreCardUrl).then(res => {
       switch (res.status) {
         case 404:
           return null;


### PR DESCRIPTION
I'd like to have the scorecard json files in the Github repositories, along with the component code.
We could have an annotation to override the URL to fetch the data from:

```diff
apiVersion: backstage.io/v1alpha1
kind: System
metadata:
  name: sample-system-1
  description: |
    A sample system
+  annotations:
+    score-card/url: /url/to/score/card.json
``` 

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
