### PR TITLE
Expose ScoreCardTable for usage in custom pages

### DIFF
--- a/.changeset/dry-shirts-kneel.md
+++ b/.changeset/dry-shirts-kneel.md
@@ -1,0 +1,5 @@
+---
+'@oriflame/backstage-plugin-score-card': patch
+---
+
+Expose ScoreCardTable for usage outside ScoreBoardPage

--- a/plugins/score-card/src/plugin.test.ts
+++ b/plugins/score-card/src/plugin.test.ts
@@ -13,10 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { scoreCardPlugin } from './plugin';
+import { scoreCardPlugin, ScoreCardTable } from './plugin';
 
 describe('score-card', () => {
   it('should export plugin', () => {
     expect(scoreCardPlugin).toBeDefined();
+  });
+
+  it('should export ScoreCardTable', () => {
+    expect(ScoreCardTable).toBeDefined();
   });
 });

--- a/plugins/score-card/src/plugin.ts
+++ b/plugins/score-card/src/plugin.ts
@@ -27,6 +27,8 @@ import { scoringDataApiRef } from './api';
 
 import { rootRouteRef } from './routes';
 
+export { ScoreCardTable } from './components/ScoreCardTable';
+
 export const scoreCardPlugin = createPlugin({
   id: 'score-card',
   routes: {


### PR DESCRIPTION
Exposing `ScoreCardTable` so it can be use in custom pages, without `ScoreBoardPage`.

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
