### PR TITLE
fix: react-router-dom is used in test

### DIFF
--- a/plugins/score-card/package.json
+++ b/plugins/score-card/package.json
@@ -66,7 +66,8 @@
     "@types/react": "^16.13.1 || ^17.0.0",
     "msw": "0.47.3",
     "cross-fetch": "3.1.5",
-    "http-server": "14.1.1"
+    "http-server": "14.1.1",
+    "react-router-dom": "6.4.3"
   },
   "files": [
     "dist",


### PR DESCRIPTION
#132 adds react-router-dom  dependency to tests. But the PR CI was not up-to-date and the `lint` step did not run, thus failing the main branch. This shall fix it.

