### PR TITLE
wikiLinkTemplate is now optional

### DIFF
--- a/.changeset/funny-jobs-hug.md
+++ b/.changeset/funny-jobs-hug.md
@@ -1,0 +1,5 @@
+---
+'@oriflame/backstage-plugin-score-card': minor
+---
+
+wikiLinkTemplate is now optionnal

--- a/plugins/score-card/README.md
+++ b/plugins/score-card/README.md
@@ -59,7 +59,7 @@ Also the server providing the data needs to have correctly configured CORS polic
 All configuration options:
 
 - `jsonDataUrl`[optional]: url for the JSON data client, see [ScoringDataJsonClient](#scoringdatajsonclient).
-- `wikiLinkTemplate`: the template for the link to the wiki. You may use any existing properties from the `EntityScoreEntry`, e.g. `"https://TBD/XXX/_wiki/wikis/XXX.wiki/{id}"`.
+- `wikiLinkTemplate`[optional]: the template for the link to the wiki. You may use any existing properties from the `EntityScoreEntry`, e.g. `"https://TBD/XXX/_wiki/wikis/XXX.wiki/{id}"` or `"{scoreUrl}"`.
 
 ### How to use the plugin
 

--- a/plugins/score-card/src/components/ScoreCard/ScoreCard.tsx
+++ b/plugins/score-card/src/components/ScoreCard/ScoreCard.tsx
@@ -79,7 +79,7 @@ const useScoringDataLoader = () => {
 
   const wikiLinkTemplate =
     config.getOptionalString('scorecards.wikiLinkTemplate') ??
-    'https://TBD/XXX/_wiki/wikis/XXX.wiki/{id}';
+    '';
 
   return { loading, value, wikiLinkTemplate, error };
 };

--- a/plugins/score-card/src/components/ScoreCard/columns/titleColumn.tsx
+++ b/plugins/score-card/src/components/ScoreCard/columns/titleColumn.tsx
@@ -28,17 +28,23 @@ export function titleColumn(
     field: 'title',
     grouping: false,
     width: '1%',
-    render: entityScoreEntry => (
-      <span>
-        <Link
-          href={getWikiUrl(wikiLinkTemplate, entityScoreEntry)}
-          target="_blank"
-          data-id={entityScoreEntry.id}
-        >
-          {entityScoreEntry.title}
-        </Link>
-        {entityScoreEntry.isOptional ? ' (Optional)' : null}
-      </span>
-    ),
+    render: entityScoreEntry => {
+      const wikiUrl = getWikiUrl(wikiLinkTemplate, entityScoreEntry);
+      return (<span>
+          {wikiUrl ? (
+          <Link
+            href={wikiUrl}
+            target="_blank"
+            data-id={entityScoreEntry.id}
+            >
+            {entityScoreEntry.title}
+          </Link>
+        ) : (
+          <>{entityScoreEntry.title}</>
+        )}
+          {entityScoreEntry.isOptional ? ' (Optional)' : null}
+        </span>
+      )
+    },
   };
 }


### PR DESCRIPTION
The Score area title column doesn't display a link anymore if the computed value is empty.
This allow  to not set `wikiLinkTemplate` and not have links pointing to nowhere.

This fixes https://github.com/Oriflame/backstage-plugins/issues/177

## Before
Links everywhere
![image](https://user-images.githubusercontent.com/5289520/232075140-d26df56d-b81b-406d-8c29-6503b8faca88.png)


## After
With the following configuration:
```yaml
scorecards:
  wikiLinkTemplate: "{scoreUrl}"
```
and json file:
```
"scoreEntries": [
        {
          "title": "GitFlow",
          "scorePercent": 100,
          "scoreSuccess": "success",
          "scoreHints": "Gitflow: 100%",
          "details": "..."
        },
        {
          "scoreUrl": "https://example.com",
          "title": "Identity Management",
          "scoreSuccess": "unknown",
          "details": "..."
        },
```

You see `GitFlow` with no link and `Identity Management` with one pointing to [https://example.com](https://example.com).
![image](https://user-images.githubusercontent.com/5289520/232074810-3cd1fac3-e590-41d9-99b9-70b534314917.png)


#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
