### PR TITLE
feat(score-card): New config jsonNameOfAllEntities

### DIFF
--- a/.changeset/smooth-dryers-confess.md
+++ b/.changeset/smooth-dryers-confess.md
@@ -1,0 +1,5 @@
+---
+'@oriflame/backstage-plugin-score-card': minor
+---
+
+New config [jsonNameOfAllEntities]

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -47,6 +47,7 @@ scaffolder:
 
 scorecards:
   jsonDataUrl: http://localhost:8090/plugins/score-card/sample-data/ #this is being served via http-server
+  jsonNameOfAllEntities: all.json
   wikiLinkTemplate: https://link-to-wiki/{id}
 
 catalog:

--- a/plugins/score-card/README.md
+++ b/plugins/score-card/README.md
@@ -59,6 +59,7 @@ Also the server providing the data needs to have correctly configured CORS polic
 All configuration options:
 
 - `jsonDataUrl`[optional]: url for the JSON data client, see [ScoringDataJsonClient](#scoringdatajsonclient).
+- `jsonNameOfAllEntities`[optional]: Json file name of all entities. Default is `all.json`
 - `wikiLinkTemplate`[optional]: the template for the link to the wiki. You may use any existing properties from the `EntityScoreEntry`, e.g. `"https://TBD/XXX/_wiki/wikis/XXX.wiki/{id}"` or `"{scoreUrl}"`.
 
 ### How to use the plugin

--- a/plugins/score-card/config.d.ts
+++ b/plugins/score-card/config.d.ts
@@ -25,6 +25,11 @@ export interface Config {
      */
     jsonDataUrl?: string;
     /**
+     * Json file name of all entities
+     * @visibility frontend
+     */
+    jsonNameOfAllEntities?: string;
+    /**
      * The template for the link to the wiki, e.g. "https://TBD/XXX/_wiki/wikis/XXX.wiki/{id}"
      * @visibility frontend
      */

--- a/plugins/score-card/src/api/ScoringDataJsonClient.ts
+++ b/plugins/score-card/src/api/ScoringDataJsonClient.ts
@@ -74,7 +74,8 @@ export class ScoringDataJsonClient implements ScoringDataApi {
 
   public async getAllScores(entityKindFilter?: string[]): Promise<EntityScoreExtended[] | undefined> {
     const jsonDataUrl = this.getJsonDataUrl();
-    const urlWithData = `${jsonDataUrl}all.json`;
+    const jsonName = this.getsJsonNameOfAllEntities();
+    const urlWithData = `${jsonDataUrl}${jsonName}`;
     let result: EntityScore[] | undefined = await fetch(urlWithData).then(
       res => {
         switch (res.status) {
@@ -105,7 +106,7 @@ export class ScoringDataJsonClient implements ScoringDataApi {
       filter: {
         'metadata.name': entity_names
 
-       },
+      },
       fields: ['kind', 'metadata.name', 'spec.owner', 'relations'],
     });
     const entities: Entity[] = response.items;
@@ -121,6 +122,13 @@ export class ScoringDataJsonClient implements ScoringDataApi {
     return (
       this.configApi.getOptionalString('scorecards.jsonDataUrl') ??
       'https://unknown-url-please-configure'
+    );
+  }
+
+  private getsJsonNameOfAllEntities() {
+    return (
+      this.configApi.getOptionalString('scorecards.jsonNameOfAllEntities') ??
+      'all.json'
     );
   }
 


### PR DESCRIPTION
Added a new parameter through which you can set the file name for all entities. In my environment.
I use gitlab for hosting score data and I plan to receive data via gitlab api (for cors to work). My work full url like this: "https://gitlab.local/api/v4/projects/6242/repository/files/all.json/raw". How can you see url have postfix **/raw** in my case

It seems to make it possible to make the name "all.json" customizable would not be superfluous

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
