### PR TITLE
breaking CI as pre-req for v20 node migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
     steps:
       - name: Checkout non PR
         uses: actions/checkout@v3


### PR DESCRIPTION
this will break the main build but it's needed for upgrade to Node.js v20
