### PR TITLE
feat(score-cards): Configure display policies to hide/show columns

### DIFF
--- a/.changeset/gold-jeans-lay.md
+++ b/.changeset/gold-jeans-lay.md
@@ -1,0 +1,5 @@
+---
+'@oriflame/backstage-plugin-score-card': minor
+---
+
+Configure display policies to hide/show owner and kind columns

--- a/plugins/score-card/config.d.ts
+++ b/plugins/score-card/config.d.ts
@@ -26,6 +26,16 @@ export interface Config {
     jsonDataUrl?: string;
     display?: {
       /**
+       * Whether to display the kind column in the score card table.
+       * @visibility frontend
+       */
+      kind?: string;
+      /**
+       * Whether to display the owner column in the score card table.
+       * @visibility frontend
+       */
+      owner?: string;
+      /**
        * Whether to display the reviewer column in the score card table.
        * @visibility frontend
        */

--- a/plugins/score-card/src/components/ScoreCardTable/ScoreCardTable.tsx
+++ b/plugins/score-card/src/components/ScoreCardTable/ScoreCardTable.tsx
@@ -79,14 +79,24 @@ export const ScoreTable = ({ title, scores }: ScoreTableProps) => {
         );
       },
     },
-    {
+  ];
+
+  if (displayPolicies.kind === DisplayPolicy.Always) {
+    columns.push({
       title: 'Kind',
       field: 'entityRef.kind',
       render: entityScore => {
         return <>{entityScore.entityRef.kind}</>;
       },
-    },
-    {
+    });
+  }
+
+  if (
+    displayPolicies.owner === DisplayPolicy.Always ||
+    (displayPolicies.owner === DisplayPolicy.IfDataPresent &&
+      scores.some(s => !!s.owner))
+  ) {
+    columns.push({
       title: 'Owner',
       field: 'owner.name',
       render: entityScore =>
@@ -97,8 +107,8 @@ export const ScoreTable = ({ title, scores }: ScoreTableProps) => {
             </EntityRefLink>
           </>
         ) : null,
-    },
-  ];
+    });
+  }
 
   if (
     displayPolicies.reviewer === DisplayPolicy.Always ||

--- a/plugins/score-card/src/config/DisplayConfig.test.ts
+++ b/plugins/score-card/src/config/DisplayConfig.test.ts
@@ -22,17 +22,29 @@ describe('display config', () => {
   it.each([
     [
       { reviewer: 'always', reviewDate: 'always' },
-      { reviewer: DisplayPolicy.Always, reviewDate: DisplayPolicy.Always },
+      { 
+        reviewer: DisplayPolicy.Always,
+        reviewDate: DisplayPolicy.Always,
+        owner: DisplayPolicy.Always,
+        kind: DisplayPolicy.Always,
+      },
     ],
     [
       { reviewer: 'never', reviewDate: 'never' },
-      { reviewer: DisplayPolicy.Never, reviewDate: DisplayPolicy.Never },
+      { 
+        reviewer: DisplayPolicy.Never, 
+        reviewDate: DisplayPolicy.Never,
+        owner: DisplayPolicy.Always,
+        kind: DisplayPolicy.Always,
+      },
     ],
     [
       { reviewer: 'if-data-present', reviewDate: 'if-data-present' },
       {
         reviewer: DisplayPolicy.IfDataPresent,
         reviewDate: DisplayPolicy.IfDataPresent,
+        owner: DisplayPolicy.Always,
+        kind: DisplayPolicy.Always,
       },
     ],
     [
@@ -40,13 +52,55 @@ describe('display config', () => {
       {
         reviewer: DisplayPolicy.Always,
         reviewDate: DisplayPolicy.IfDataPresent,
+        owner: DisplayPolicy.Always,
+        kind: DisplayPolicy.Always,
       },
     ],
     [
       { reviewer: 'never' },
-      { reviewer: DisplayPolicy.Never, reviewDate: DisplayPolicy.Always },
+      { 
+        reviewer: DisplayPolicy.Never,
+        reviewDate: DisplayPolicy.Always,
+        owner: DisplayPolicy.Always,
+        kind: DisplayPolicy.Always,
+      },
     ],
-    [{}, { reviewer: DisplayPolicy.Always, reviewDate: DisplayPolicy.Always }],
+    [
+      { owner: 'never' },
+      { 
+        reviewer: DisplayPolicy.Always,
+        reviewDate: DisplayPolicy.Always,
+        owner: DisplayPolicy.Never,
+        kind: DisplayPolicy.Always,
+      },
+    ],
+    [
+      { owner: 'if-data-present' },
+      { 
+        reviewer: DisplayPolicy.Always,
+        reviewDate: DisplayPolicy.Always,
+        owner: DisplayPolicy.IfDataPresent,
+        kind: DisplayPolicy.Always,
+      },
+    ],
+    [
+      { kind: 'never' },
+      { 
+        reviewer: DisplayPolicy.Always,
+        reviewDate: DisplayPolicy.Always,
+        owner: DisplayPolicy.Always,
+        kind: DisplayPolicy.Never,
+      },
+    ],
+    [
+      {}, 
+      { 
+        reviewer: DisplayPolicy.Always,
+        reviewDate: DisplayPolicy.Always,
+        owner: DisplayPolicy.Always,
+        kind: DisplayPolicy.Always,
+      }
+    ],
   ])('gets expected display policies from config', (policies, expected) => {
     const mockConfig = new MockConfigApi({ scorecards: { display: policies } });
 

--- a/plugins/score-card/src/config/DisplayConfig.ts
+++ b/plugins/score-card/src/config/DisplayConfig.ts
@@ -31,6 +31,12 @@ export class DisplayConfig {
       reviewer:
         (displayConfig?.getOptionalString('reviewer') as DisplayPolicy) ??
         DisplayPolicy.Always,
+      owner:
+        (displayConfig?.getOptionalString('owner') as DisplayPolicy) ??
+        DisplayPolicy.Always,
+      kind:
+        (displayConfig?.getOptionalString('kind') as DisplayPolicy) ??
+        DisplayPolicy.Always,
       reviewDate:
         (displayConfig?.getOptionalString('reviewDate') as DisplayPolicy) ??
         DisplayPolicy.Always,

--- a/plugins/score-card/src/config/types.ts
+++ b/plugins/score-card/src/config/types.ts
@@ -21,6 +21,8 @@ export enum DisplayPolicy {
 }
 
 export interface DisplayPolicies {
+  kind: DisplayPolicy,
+  owner: DisplayPolicy,
   reviewer: DisplayPolicy;
   reviewDate: DisplayPolicy;
 }


### PR DESCRIPTION
Configure display policies to hide/show owner and kind columns
We needed to hide owner and kind columns, since we have no use for them.

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)

<img width="1266" alt="Screenshot 2024-12-02 at 08 42 19" src="https://github.com/user-attachments/assets/d43ad053-99b2-4ea3-9fd3-7440582467b9">
