### PR TITLE
Fix playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,7 @@ name: 'CI workflow'
 
 on:
   workflow_dispatch:
-  pull_request_target:
-    branches:
-      - main
   push:
-    branches:
-      - main
 
 permissions:
   contents: read

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@backstage/e2e-test-utils": "^0.1.0",
     "@backstage/repo-tools": "^0.5.2",
     "@changesets/cli": "2.27.1",
-    "@playwright/test": "^1.43.0",
+    "@playwright/test": "^1.50.1",
     "@spotify/prettier-config": "14.1.6",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7943,6 +7943,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@playwright/test@npm:^1.50.1":
+  version: 1.50.1
+  resolution: "@playwright/test@npm:1.50.1"
+  dependencies:
+    playwright: "npm:1.50.1"
+  bin:
+    playwright: cli.js
+  checksum: 10c0/77c1a7cfaca7b3b88804256bb4c0e15c54b8df02690298086ef4a4fc8c2a42b99b69ba1b83906d00cc7ddb322ce8b2f19f0238f189913607c679779a4d132da1
+  languageName: node
+  linkType: hard
+
 "@pmmmwh/react-refresh-webpack-plugin@npm:^0.5.7":
   version: 0.5.11
   resolution: "@pmmmwh/react-refresh-webpack-plugin@npm:0.5.11"
@@ -24059,7 +24070,7 @@ __metadata:
     "@backstage/e2e-test-utils": "npm:^0.1.0"
     "@backstage/repo-tools": "npm:^0.5.2"
     "@changesets/cli": "npm:2.27.1"
-    "@playwright/test": "npm:^1.43.0"
+    "@playwright/test": "npm:^1.50.1"
     "@spotify/prettier-config": "npm:14.1.6"
     "@types/react": "npm:^18.2.48"
     "@types/react-dom": "npm:^18.2.18"
@@ -24852,6 +24863,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"playwright-core@npm:1.50.1":
+  version: 1.50.1
+  resolution: "playwright-core@npm:1.50.1"
+  bin:
+    playwright-core: cli.js
+  checksum: 10c0/c158764257d870897c31807a830ddcc3f5aaf4376719e05aeada3489a01f751650b2dc43e027201a40405a1b075084e89f58cd3730a985a229efe9d8cecfe360
+  languageName: node
+  linkType: hard
+
 "playwright@npm:1.43.1":
   version: 1.43.1
   resolution: "playwright@npm:1.43.1"
@@ -24864,6 +24884,21 @@ __metadata:
   bin:
     playwright: cli.js
   checksum: 10c0/7edc1e12b8f3b791c7e8d1f9c595be35c6eaf8100f9550d5e35e979aca0bc229734e65f200f2a02dc7e21630cc40c171d7b25f5f6ccf628c79e4a2d4690909ab
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.50.1":
+  version: 1.50.1
+  resolution: "playwright@npm:1.50.1"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.50.1"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 10c0/b292ee6e0d122748a3d024b85ace86a0d9c848fc4121685d90ffc5d43d6bcf13ed7dc7488b1055f69040599c420052306ccba6fabfe2f69a15fc109c55171207
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
bump playwright to 1.50.1 as this should fix `Package libicu70 is not available, but is referred to by another package` CI error